### PR TITLE
Fix workflow permissions for reusable container build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   build:
     uses: zavestudios/platform-pipelines/.github/workflows/container-build.yml@main


### PR DESCRIPTION
## Summary
- add explicit workflow permissions required by reusable `container-build.yml`
- allow `packages: write` and `id-token: write` in caller workflow

## Why
After PR #12 merged, build workflow validation failed due to insufficient default token permissions for the called reusable workflow.

## Testing
- workflow-only change; validated against GitHub workflow permission error output