### PR TITLE
feat(image): trim etl-runner image and add promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,25 @@
+name: Promote ETL Runner Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      digest:
+        description: "Digest sha256:..."
+        required: true
+      environment:
+        description: "Environment tag (use bootstrap for gitops consumption)"
+        required: true
+
+permissions:
+  packages: write
+  id-token: write
+
+jobs:
+  promote:
+    uses: zavestudios/platform-pipelines/.github/workflows/container-promote.yml@c0aa80bb405fa24ede5ebcf1c40b0be90328386c
+    with:
+      image: ghcr.io/zavestudios/zavestudios-etl-runner
+      digest: ${{ inputs.digest }}
+      environment: ${{ inputs.environment }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,12 @@ FROM python:3.11-slim AS builder
 
 WORKDIR /app
 
-ARG AIRFLOW_VERSION=2.9.3
-ARG PYTHON_VERSION=3.11
-ARG AIRFLOW_CONSTRAINTS_URL=https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt
-
-# Copy and install Python dependencies
-COPY requirements.txt .
+COPY requirements-runner.txt .
 RUN python -m pip install --no-cache-dir --upgrade pip && \
-    python -m pip install --no-cache-dir -c "${AIRFLOW_CONSTRAINTS_URL}" -r requirements.txt
+    python -m pip install --no-cache-dir -r requirements-runner.txt
 
 # Copy application code
 COPY etl/ ./etl/
-COPY scripts/ ./scripts/
-COPY dags/ ./dags/
 
 # Compile Python files to bytecode for faster startup and smaller runtime footprint
 RUN python -m compileall -b /app

--- a/requirements-runner.txt
+++ b/requirements-runner.txt
@@ -1,0 +1,4 @@
+sqlalchemy
+pydantic
+pydantic-settings
+psycopg2-binary


### PR DESCRIPTION
## Summary

- Replaces `requirements.txt` with `requirements-runner.txt` in the Dockerfile, dropping `apache-airflow`, `apache-airflow-providers-cncf-kubernetes`, and `pytest` from the runner image — none of these are needed at runtime
- Removes `scripts/` and `dags/` from the image COPY — the runner only needs `etl/`
- Adds `.github/workflows/promote.yml` following the `keycloak-promote.yml` pattern for tagging a built digest for gitops consumption

## Why

The original Dockerfile installed full Airflow into the runner pod image. Airflow and its 400+ transitive deps have no business being in a pod that just runs ETL code. This also removes the Airflow constraints URL fetch at build time.

## Related

Closes zavestudios/gitops#188 (item 4 of 5 — etl-runner image)

## Test plan

- [ ] Build workflow passes on this branch
- [ ] Resulting image is substantially smaller than the previous build
- [ ] `python -c "print('hello')"` works in the image (smoke test for hello_k8s DAG)
- [ ] After merge, run promote workflow with the pushed digest to tag for gitops