### PR TITLE
fix(dag): set service_account_name on KubernetesPodOperator

### DIFF
--- a/dags/hello_k8s.py
+++ b/dags/hello_k8s.py
@@ -9,6 +9,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperato
 
 NAMESPACE = os.getenv("AIRFLOW_RUN_NAMESPACE", "airflow")
 ETL_IMAGE = os.getenv("ETL_IMAGE", "zavestudios/etl-runner:0.1.0")
+SERVICE_ACCOUNT = os.getenv("AIRFLOW_RUN_SERVICE_ACCOUNT", NAMESPACE)
 
 
 with DAG(
@@ -23,6 +24,7 @@ with DAG(
         name="hello-k8s",
         namespace=NAMESPACE,
         image=ETL_IMAGE,
+        service_account_name=SERVICE_ACCOUNT,
         cmds=["python", "-c"],
         arguments=["print('hello from kubernetes pod operator')"],
         in_cluster=True,


### PR DESCRIPTION
## Problem

KPO pods were running as the `default` SA in `listings-ingest`, which has no `imagePullSecrets`. GHCR image pulls failed with 401 Unauthorized.

## Fix

Adds `service_account_name=SERVICE_ACCOUNT` to `KubernetesPodOperator`. `SERVICE_ACCOUNT` is read from the `AIRFLOW_RUN_SERVICE_ACCOUNT` env var, defaulting to `NAMESPACE` (i.e. `listings-ingest`). The `listings-ingest` SA has `imagePullSecrets: [{name: ghcr-secret}]` so pods inherit pull credentials automatically.

Relates to zavestudios/gitops#188