### PR TITLE
fix(ci): update platform-pipelines pin for provenance/sbom fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    uses: zavestudios/platform-pipelines/.github/workflows/container-build.yml@c0aa80bb405fa24ede5ebcf1c40b0be90328386c
+    uses: zavestudios/platform-pipelines/.github/workflows/container-build.yml@d6a1e8756e6bf0611a754dca4a139aa6a688f74a
     with:
       image_name: ${{ github.repository_owner }}/zavestudios-etl-runner
       dockerfile: Dockerfile


### PR DESCRIPTION
Points to the commit that makes provenance and sbom configurable (defaulting to false), resolving the containerd layer mismatch error on k3s caused by OCI attestation artifacts in the image index.