### PR TITLE
fix(image): replace distroless runtime with python:3.11-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,22 +13,17 @@ COPY etl/ ./etl/
 # Compile Python files to bytecode for faster startup and smaller runtime footprint
 RUN python -m compileall -b /app
 
-# Stage 2: Runtime - Minimal distroless image
-FROM gcr.io/distroless/python3-debian12:latest
+# Stage 2: Runtime
+FROM python:3.11-slim
 
 WORKDIR /app
 
-# Set Python path to include installed packages
 ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages:/app
 
-# Copy Python dependencies from builder
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-
-# Copy application code (bytecode preferred, source as fallback)
 COPY --from=builder /app /app
 
-# Run as non-root user (numeric UID for distroless compatibility)
-# UID 1000 matches the 'etl' user we previously created
-USER 1000:1000
+RUN useradd -r -u 1000 -g 0 etl
+USER 1000:0
 
 ENTRYPOINT ["python"]


### PR DESCRIPTION
## Summary

- Replaces `gcr.io/distroless/python3-debian12:latest` runtime stage with `python:3.11-slim`
- Root cause: distroless uses OCI layer media types incompatible with the k3s containerd version — pod startup fails with `mismatched image rootfs and manifest layers` regardless of attestation settings
- Tested locally: `docker build --platform linux/amd64` + `python -c "print(...)"` + import validation all pass
- Adds a non-root `etl` user (UID 1000) to preserve the security posture

## Test plan

- [ ] CI build passes (Trivy scan + Cosign sign)
- [ ] Run promote workflow, get new digest
- [ ] Update HelmRelease ETL_IMAGE digest in gitops
- [ ] Re-trigger `hello_k8s` DAG smoke test — pod should reach Running state and print output

🤖 Generated with [Claude Code](https://claude.com/claude-code)