### PR TITLE
fix(dag): declare empty capability additions

### DIFF
--- a/dags/listings_ingest.py
+++ b/dags/listings_ingest.py
@@ -29,7 +29,7 @@ CONTAINER_SECURITY_CONTEXT = k8s.V1SecurityContext(
     run_as_non_root=True,
     allow_privilege_escalation=False,
     read_only_root_filesystem=True,
-    capabilities=k8s.V1Capabilities(drop=["ALL"]),
+    capabilities=k8s.V1Capabilities(add=[], drop=["ALL"]),
 )
 
 # Writable volume mounts for read-only filesystem


### PR DESCRIPTION
## Summary

Declare that ETL task containers add no Linux capabilities while continuing to drop all capabilities.

## Root cause

The enforced Kyverno capability policy evaluates the explicit capability-add set on dynamically created Airflow task pods.

## Validation

- `python3 -m py_compile dags/listings_ingest.py`
- `git diff --check`

The full pytest suite was not run locally because pytest is not installed in the local Python environment.