### PR TITLE
fix(dag): set container user and group

### DIFF
--- a/dags/listings_ingest.py
+++ b/dags/listings_ingest.py
@@ -26,6 +26,8 @@ SECURITY_CONTEXT = k8s.V1PodSecurityContext(
 )
 
 CONTAINER_SECURITY_CONTEXT = k8s.V1SecurityContext(
+    run_as_user=1000,
+    run_as_group=1000,
     run_as_non_root=True,
     allow_privilege_escalation=False,
     read_only_root_filesystem=True,


### PR DESCRIPTION
## Summary

Set the ETL container's non-root user and group directly in addition to its pod-level security context.

## Root cause

The deployed Big Bang Kyverno policies reject the pod-level fallback used by dynamically created Airflow task pods.

## Validation

- `python3 -m py_compile dags/listings_ingest.py`
- `git diff --check`