### PR TITLE
feat: read input CSV from S3/MinIO (#206)

### DIFF
--- a/dags/listings_ingest.py
+++ b/dags/listings_ingest.py
@@ -47,18 +47,28 @@ VOLUMES = [
 
 
 def _secret_env_vars() -> list[k8s.V1EnvVar]:
-    """Build env vars from K8s Secret (ESO-sourced from Vault)"""
-    secret_name = "listings-ingest-db"
-    keys = ["DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_SSLMODE"]
-    return [
+    """Build env vars from K8s Secrets (ESO-sourced from Vault)"""
+    db_keys = ["DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_SSLMODE"]
+    storage_keys = ["MINIO_ACCESS_KEY", "MINIO_SECRET_KEY", "MINIO_ENDPOINT"]
+    env_vars = [
         k8s.V1EnvVar(
             name=key,
             value_from=k8s.V1EnvVarSource(
-                secret_key_ref=k8s.V1SecretKeySelector(name=secret_name, key=key)
+                secret_key_ref=k8s.V1SecretKeySelector(name="listings-ingest-db", key=key)
             ),
         )
-        for key in keys
+        for key in db_keys
     ]
+    env_vars += [
+        k8s.V1EnvVar(
+            name=key,
+            value_from=k8s.V1EnvVarSource(
+                secret_key_ref=k8s.V1SecretKeySelector(name="listings-ingest-storage", key=key)
+            ),
+        )
+        for key in storage_keys
+    ]
+    return env_vars
 
 
 def _job_args(stage: str) -> list[str]:

--- a/etl/sources/csv.py
+++ b/etl/sources/csv.py
@@ -1,6 +1,46 @@
 import csv
+import os
+import tempfile
+from urllib.parse import urlparse
+
+
+def _download_s3(s3_url: str) -> str:
+    import boto3
+
+    parsed = urlparse(s3_url)
+    bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+
+    endpoint = os.environ.get("MINIO_ENDPOINT")
+    access_key = os.environ.get("MINIO_ACCESS_KEY")
+    secret_key = os.environ.get("MINIO_SECRET_KEY")
+    if not all([endpoint, access_key, secret_key]):
+        raise EnvironmentError(
+            "MINIO_ENDPOINT, MINIO_ACCESS_KEY, and MINIO_SECRET_KEY must be set for s3:// paths"
+        )
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+    )
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
+    client.download_fileobj(bucket, key, tmp)
+    tmp.close()
+    return tmp.name
 
 
 def read_listings(path: str) -> list[dict]:
-    with open(path, newline="", encoding="utf-8") as handle:
-        return list(csv.DictReader(handle))
+    tmp_path = None
+    if path.startswith("s3://"):
+        tmp_path = _download_s3(path)
+        path = tmp_path
+
+    try:
+        with open(path, newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+    finally:
+        if tmp_path:
+            os.unlink(tmp_path)

--- a/requirements-runner.txt
+++ b/requirements-runner.txt
@@ -2,3 +2,4 @@ sqlalchemy
 pydantic
 pydantic-settings
 psycopg2-binary
+boto3


### PR DESCRIPTION
## Summary

- `etl/sources/csv.py` — `read_listings` now detects `s3://` paths, downloads the object to a tempfile via boto3, parses it, then cleans up. Local file paths are unchanged.
- `requirements-runner.txt` — adds `boto3`
- `dags/listings_ingest.py` — `_secret_env_vars()` now also injects `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, and `MINIO_ENDPOINT` from the `listings-ingest-storage` Secret (ESO-sourced from Vault) into each KubernetesPodOperator pod

## Behaviour

`ETL_INPUT_PATH` controls the source path, as before. Set it to `s3://listings-ingest/input/listings.csv` to read from MinIO. The default (`/data/listings.csv`) continues to work locally.

## Dependencies

- `listings-ingest-storage` Secret must exist in the `listings-ingest` namespace before pods start — provisioned by the ExternalSecret in gitops PR #316
- Vault path `tenants/listings-ingest/storage` must be populated — covered by kubernetes-platform-infrastructure PR #59
- MinIO itself must be running and the bucket created — covered by gitops PR #316 (pending render-parity sign-off)
- `ETL_INPUT_PATH` env var must be set to the S3 path in the Airflow HelmRelease — follow-on in the airflow repo

## Test plan

- [ ] Existing tests pass (`pytest`)
- [ ] After MinIO is running: upload a sample CSV to `s3://listings-ingest/input/listings.csv` and trigger the DAG manually with `ETL_INPUT_PATH` set
- [ ] Confirm pod logs show successful download and row counts

## Related

- gitops#206 (primary issue)
- gitops PR #316 — MinIO Flux ownership
- kubernetes-platform-infrastructure PR #59 — Vault policy IaC