### PR TITLE
fix: use S3v4 signing for MinIO downloads

### DIFF
--- a/etl/sources/csv.py
+++ b/etl/sources/csv.py
@@ -27,7 +27,10 @@ def _download_s3(s3_url: str) -> str:
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
         verify=False,
-        config=botocore.config.Config(s3={"addressing_style": "path"}),
+        config=botocore.config.Config(
+            signature_version="s3v4",
+            s3={"addressing_style": "path"},
+        ),
     )
 
     tmp = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)


### PR DESCRIPTION
## Summary

- Force S3v4 signing for MinIO downloads while keeping path-style addressing.
- Keeps TLS verification disabled for the current internal MinIO endpoint debugging path.

## Root Cause

The ETL runner now reaches MinIO and bypasses the internal certificate validation issue, but boto3 receives `403 Forbidden` on `HeadObject` while the same Kubernetes secret credentials work through `mc`. Forcing S3v4 removes boto3 signing ambiguity against MinIO.

## Testing

- `python3 -m py_compile etl/sources/csv.py`
- Docker Compose validation was attempted, but Docker Buildx could not update its activity cache under `~/.docker` from this side session.
