### PR TITLE
fix: fetch MinIO CSV with GetObject

### DIFF
--- a/etl/sources/csv.py
+++ b/etl/sources/csv.py
@@ -33,10 +33,10 @@ def _download_s3(s3_url: str) -> str:
         ),
     )
 
-    tmp = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
-    client.download_fileobj(bucket, key, tmp)
-    tmp.close()
-    return tmp.name
+    response = client.get_object(Bucket=bucket, Key=key)
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp.write(response["Body"].read())
+        return tmp.name
 
 
 def read_listings(path: str) -> list[dict]:


### PR DESCRIPTION
## Summary

- Replace boto3 `download_fileobj()` with direct `get_object()` for MinIO CSV fetches.
- Avoids the helper's internal `HeadObject` preflight, which currently returns 403 against the MinIO endpoint even though the same secret can read the object with `mc`.

## Testing

- `python3 -m py_compile etl/sources/csv.py`

## Context

The retained Airflow child pod showed `HeadObject` failing with 403. The bucket object exists and the Kubernetes secret credentials can read it via MinIO Client.
