### PR TITLE
Keep listings ingest task pods for debugging

### DIFF
--- a/dags/listings_ingest.py
+++ b/dags/listings_ingest.py
@@ -154,7 +154,7 @@ with DAG(
             volumes=VOLUMES,
             env_vars=_secret_env_vars(),
             in_cluster=True,
-            on_finish_action="delete_pod",
+            on_finish_action="keep_pod",
             get_logs=True,
             do_xcom_push=False,
             container_resources=k8s.V1ResourceRequirements(
@@ -177,7 +177,7 @@ with DAG(
             volumes=VOLUMES,
             env_vars=_secret_env_vars(),
             in_cluster=True,
-            on_finish_action="delete_pod",
+            on_finish_action="keep_pod",
             get_logs=True,
             do_xcom_push=False,
             container_resources=k8s.V1ResourceRequirements(


### PR DESCRIPTION
## Summary

- Keep `load_postgres` and `dq_assertions` KubernetesPodOperator pods after completion.
- `extract_validate` was already set to keep pods for debugging.

## Why

The MinIO fetch path now reaches `load_postgres`; keeping all task pods gives us logs for the next failing stage instead of losing the pod on finish.

## Testing

- `python3 -m py_compile dags/listings_ingest.py`
- `git diff --check`

## Notes

- DAG-only change. Airflow git-sync should pick this up from `main` after merge; no ETL image digest update is required.
